### PR TITLE
Editing article title currently breaks the way images can be fetched.…

### DIFF
--- a/src/components/Admin/PostArticle/EditArticle.jsx
+++ b/src/components/Admin/PostArticle/EditArticle.jsx
@@ -133,6 +133,11 @@ class EditArticle extends Component {
         })
     }
 
+    // step delete should check if the step had an image and then delete from db if it does.
+    // When deleting a step, how will that effect other step's images when being loaded ?
+    // MAy need to refactor to not number the images but instead just do articleTitle_imagename.
+    // Imagename would need to be available to the frontend when grabbing article.
+    // Would need a test to check if name is duplicate, and notify the image will have to be renamed.
     handleStepDelete = ( event ) => {
         event.preventDefault();
         const target = event.target;
@@ -243,6 +248,9 @@ class EditArticle extends Component {
     // steps will need to be renamed to selectedArticle.steps.map()
     // Can remove the axios.get altogether as we already have the article
     // Index that the article is to be "set" at is in this.state.articleIndex
+
+    // Editing an article title also breaks image fetching.
+    // Need to find a way to store image names that will be retrievable if article is edited.
     handleSubmit = () => {
         const { articleIndex, category, selectedArticle, title } = this.state;
 

--- a/src/components/ArticleViewingPage/ActualArticle.jsx
+++ b/src/components/ArticleViewingPage/ActualArticle.jsx
@@ -23,10 +23,11 @@ const ActualArticle = ( props ) => {
                     currentStep.imgName
                     ? 
                         <li key={index} className="article-step__image">
-                            <button key={currentStep.stepIndex} 
+                            <button key={currentStep.imgIndex} 
                                 className="article-step-button"
-                                currentstep={currentStep.stepIndex}
-                                onClick={(event) => props.click(event, currentStep.stepIndex)} >
+                                currentstep={currentStep.imgIndex}
+                                onClick={(event) => props.click(event, currentStep.imgIndex)}
+                                value={currentStep} >
                                     {currentStep.step}
                             </button>
                         </li> 

--- a/src/components/ArticleViewingPage/ArticleActive.jsx
+++ b/src/components/ArticleViewingPage/ArticleActive.jsx
@@ -30,6 +30,7 @@ class ArticleActive extends React.Component {
     };
 
     changeDisplayImage = ( event, value ) => {
+        console.log(value)
         const currentStep = value
 
         const { allData, currentStepIndex } = this.state
@@ -49,7 +50,7 @@ class ArticleActive extends React.Component {
             params: {
                 title: title,
                 imgName: imgName,
-                stepIndex: currentStepIndex
+                imgIndex: currentStep
             }
         }
 


### PR DESCRIPTION
… Need to figure out a new img naming structure that will allow to post/retreive without issue. title_v2_1.jpg is not the name of the image because it was initially posted with title_1.jpg. Maybe use some sort of randomized string that is used for that article that sticks with that article even if it's renamed?